### PR TITLE
docs(readme): atualizar porta padrão da API para 3100

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Microserviço **users** com **NestJS** (TypeScript), **TypeORM** e **PostgreSQL*
 Docker/Compose, migrações, DTOs/validação, documentação **Swagger**, **testes** (unit/E2E) e **health check**. Arquitetura
 database-per-service, preparada para evolução com eventos (Outbox/Sagas) e API Gateway/BFF.
 
-> Porta padrão da API: **3000** · Banco: **usersdb** (PostgreSQL)
+> Porta padrão da API: **3100** · Banco: **usersdb** (PostgreSQL)
 
 ---
 


### PR DESCRIPTION
Altera referências no README de 3000 → 3100. Ajustar também .env/compose/main.ts quando disponíveis.