### PR TITLE
fix(e2e): supertest default import + HttpServer; lint clean

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,30 @@
+// .eslintrc.cjs
+module.exports = {
+  root: true,
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    project: ['tsconfig.eslint.json'],
+    tsconfigRootDir: __dirname,
+  },
+  plugins: ['@typescript-eslint', 'prettier'],
+  extends: [
+    'plugin:@typescript-eslint/recommended',
+    'prettier',
+  ],
+  // Mantém o lint forte no código de app
+  overrides: [
+    {
+      // Inclui unit/integration e E2E explícito
+      files: ['**/*.spec.ts', '**/*.e2e-spec.ts', 'test/**/*.ts'],
+      env: { jest: true, node: true },
+      rules: {
+        '@typescript-eslint/no-unsafe-assignment': 'off',
+        '@typescript-eslint/no-unsafe-argument': 'off',
+        '@typescript-eslint/no-unsafe-call': 'off',
+        '@typescript-eslint/no-unsafe-member-access': 'off',
+        '@typescript-eslint/no-unsafe-return': 'off',
+      },
+    },
+  ],
+  ignorePatterns: ['.eslintrc.cjs'],
+};

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -1,12 +1,14 @@
 // test/app.e2e-spec.ts
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
-import request from 'supertest'; // 👈 default import
+import request from 'supertest';
+import { Server } from 'http';
 
-import { AppModule } from './../src/app.module';
+import { AppModule } from '../src/app.module';
 
 describe('AppController (e2e)', () => {
   let app: INestApplication;
+  let server: Server;
 
   beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
@@ -15,16 +17,16 @@ describe('AppController (e2e)', () => {
 
     app = moduleFixture.createNestApplication();
     await app.init();
-  });
 
-  it('/ (GET)', async () => {
-    await request(app.getHttpServer()) // 👈 usa await, não retorna
-      .get('/')
-      .expect(200)
-      .expect('Hello World!');
+    // evita passar `any` para o supertest
+    server = app.getHttpServer() as unknown as Server;
   });
 
   afterAll(async () => {
     await app.close();
+  });
+
+  it('/ (GET)', async () => {
+    await request(server).get('/').expect(200).expect('Hello World!');
   });
 });

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "types": ["node", "jest"],
+    "useDefineForClassFields": false,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}


### PR DESCRIPTION
• tsconfig.eslint.json: esModuleInterop/ASDI + types jest
• E2E: supertest em cima do HttpServer (sem any)
• Lint e testes passam localmente